### PR TITLE
Solved unicode problem some more

### DIFF
--- a/git_diff_xlsx.py
+++ b/git_diff_xlsx.py
@@ -36,7 +36,10 @@ def parse(infile,outfile):
     outfile.write("File last edited by " + book.user_name + "\n")
 
     def get_cells(sheet, rowx, colx):
-        value = unicode(sheet.cell_value(rowx, colx))
+        try:
+            value = unicode(sheet.cell_value(rowx, colx))
+        except:
+            value = ''
         if (rowx,colx) in sheet.cell_note_map.keys():
             value += ' <<' + unicodedata.normalize('NFKD', unicode(sheet.cell_note_map[rowx,colx].text)).encode('ascii', 'ignore') + '>>'
         return value

--- a/git_diff_xlsx.py
+++ b/git_diff_xlsx.py
@@ -36,7 +36,10 @@ def parse(infile,outfile):
     outfile.write("File last edited by " + book.user_name + "\n")
 
     def get_cells(sheet, rowx, colx):
-        return sheet.cell_value(rowx, colx)
+        value = unicode(sheet.cell_value(rowx, colx))
+        if (rowx,colx) in sheet.cell_note_map.keys():
+            value += ' <<' + unicodedata.normalize('NFKD', unicode(sheet.cell_note_map[rowx,colx].text)).encode('ascii', 'ignore') + '>>'
+        return value
 
     # loop over worksheets
 

--- a/git_diff_xlsx.py
+++ b/git_diff_xlsx.py
@@ -18,6 +18,7 @@
 
 import xlrd as xl
 import sys
+import unicodedata
 
 def parse(infile,outfile):
     """
@@ -43,13 +44,17 @@ def parse(infile,outfile):
         # find non empty cells
         sheet = book.sheet_by_index(index)
         outfile.write("=================================\n")
-        outfile.write("Sheet: " + sheet.name + "[ " + str(sheet.nrows) + " , " + str(sheet.ncols) + " ]\n")
+        sheetname = unicodedata.normalize('NFKD', unicode(sheet.name)).encode('ascii', 'ignore')
+        outfile.write("Sheet: " + sheetname + "[ " + str(sheet.nrows) + " , " + str(sheet.ncols) + " ]\n")
         outfile.write("=================================\n")
         for row in range(0,sheet.nrows):
             for col in range(0,sheet.ncols):
                 content = get_cells(sheet, row, col)
                 if content <> "":
-                    outfile.write("    " + unicode(xl.cellname(row,col)) + ": " + unicode(content) + "\n")
+                    output = '    ' + xl.cellname(row,col) + ': '
+                    output += unicodedata.normalize('NFKD', unicode(content)).encode('ascii', 'ignore')
+                    output += '\n'
+                    outfile.write(output)
         print "\n"
 
 # output cell address and contents of cell

--- a/git_diff_xlsx.py
+++ b/git_diff_xlsx.py
@@ -54,7 +54,7 @@ def parse(infile,outfile):
             for col in range(0,sheet.ncols):
                 content = get_cells(sheet, row, col)
                 if content <> "":
-                    output = '    ' + xl.cellname(row,col) + ': '
+                    output = '    ' + xl.cellname(row,col) + ':\n        '
                     output += unicodedata.normalize('NFKD', unicode(content)).encode('ascii', 'ignore')
                     output += '\n'
                     outfile.write(output)


### PR DESCRIPTION
Ignore unconvertible unicode characters in sheet name and cell content

I had a spreadsheet with German umlauts in sheet names as well as umlauts and other Unicode characters in some cells, throwing UnicodeEncodeErrors. The proposed changes solved my problem.
